### PR TITLE
batch wx operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Once you've built your final `Sketch`, you can call `Sketch.run(sketch)` to rend
 
 ### Known Issues
 
-There is currently some weirdness that the `:wx` window does not always paint on first load. It will generally work if you close and rerun the sketch - Unfortunately I've not been able to get to the bottom of that in the time limit.
-
 In addition, I unfortunately only had access to a MacBook this weekend. I am not aware of
 any reasons why things _shouldn't_ work as expected on other operating systems, but figured I'd mention it just in case...
 
@@ -156,4 +154,4 @@ Thinking beyond this hackathon, there are many things that could (should) probab
 - [ ] More graceful starting of the wx object when calling `Sketch.run/1`
 - [ ] Test coverage
 - [ ] Friendly errors
-- [ ] Figure out why the `wx` window sometimes doesn't get the render message?
+- [x] Figure out why the `wx` window sometimes doesn't get the render message?


### PR DESCRIPTION
I was playing with this and was annoyed by wx not always rendering. I've grepped and browsed through the OTP source and found it was frequently using `wx:batch/1`. By batching the operations we block the wx server thread and ensure we always receive the handle_sync_event/3 callback. At least it now always renders directly in my testing :-)